### PR TITLE
Fixed Termcolor Bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # spongebob-cli
 Watch classic spongebob from the terminal!
+Thanks to everyone that is starring, forking, writing issues, pull requesting and just users of spongebob-cli!
 
-![image](https://user-images.githubusercontent.com/81049050/150638868-18f6f51b-71e8-4d63-aa4c-2ebc2ec9c322.png)
+![spongebob](https://user-images.githubusercontent.com/81049050/150676918-9714a54a-06ea-40b2-9959-18f222e3fca6.gif)
 
 # Dependecies (all python dependecies will automatically be installed):
 1.  mpv player https://mpv.io/

--- a/spongebob-cli
+++ b/spongebob-cli
@@ -10,6 +10,10 @@ try:
 except ImportError:
     # Using python color codes instead of termcolor if it isn't found
     print("\033[1;31;40mOne or more library is missing! Check the list of libraries!")
+    # Wait 10 seconds and then exit the application
+    import time
+    time.sleep(10)
+    exit()
 
 episodes = []
 counter = 0

--- a/spongebob-cli
+++ b/spongebob-cli
@@ -8,7 +8,8 @@ try:
     from termcolor import colored
 
 except ImportError:
-    print(colored("One or more library is missing! Check the list of libraries!", "red"))
+    # Using python color codes instead of termcolor if it isn't found
+    print("\033[1;31;40mOne or more library is missing! Check the list of libraries!")
 
 episodes = []
 counter = 0


### PR DESCRIPTION
When one of the libraries is not found it prints out a red message with termcolor. But that can lead to errors if termcolor is not found. So I changed it to the python color codes so it also works if termcolor is not found. also exits the application if one of the modules isn't found. fixes #6