### PR TITLE
Specify if dependencies are Python dependencies or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Thanks to everyone that is starring, forking, writing issues, pull requesting an
 
 
 # Dependecies (all python dependecies will automatically be installed):
-1.  mpv player https://mpv.io/
-2.  youtube-dl https://github.com/ytdl-org
+1.  mpv player https://mpv.io/  (Must be installed through a package manager)
+2.  youtube-dl https://github.com/ytdl-org  (Python dependency)
 
 # Usage:
 ```


### PR DESCRIPTION
I had no idea was mpv player was prior to using this, so I'd rather not have others go through that same pain.