### PR TITLE
Removing quit messages from SystemExit exceptions so exit status is 0

### DIFF
--- a/spongebob-cli
+++ b/spongebob-cli
@@ -237,7 +237,8 @@ try:
 
             except ValueError or AttributeError:
                 if video_input in ["exit", "quit", "close", "q"]:
-                    raise SystemExit("Quitting the program!")
+                    print("Quitting the program!")
+                    raise SystemExit()
 
                 print(colored("You need to type a number!", "red"))
                 continue
@@ -252,4 +253,5 @@ try:
 
 
 except KeyboardInterrupt:
-    raise SystemExit(colored("\nUser interruped with the operation, aborting.", "red"))
+    print(colored("\nUser interruped with the operation, aborting.", "red"))
+    raise SystemExit()


### PR DESCRIPTION
The lines of code that raise SystemExit for the program to leave have arguments, those being simple quit messages, which mean when the program leaves it will return 1. This has been fixed by using a print instead.