### PR TITLE
Fix failed removal after default installation

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -4,7 +4,7 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
-# Deletes spongebob-cli from /usr/bin/
-rm /usr/bin/spongebob-cli
+# Deletes spongebob-cli executable
+rm /usr/bin/spongebob-cli || rm /usr/local/bin/spongebob-cli 
 
-spongebob-cli || echo "spongebob-cli has been sucesfully uninstalled."
+echo "spongebob-cli has been sucesfully uninstalled."


### PR DESCRIPTION
Some Unix Systems install this software under /usr/local/bin,
and the uninstall script was not considering  this.

Now, an `OR` statement was included to deal whether the app is
inside /usr/bin or /usr/local/bin

*Also:
After failed removal, the app is not launched anymore