### PR TITLE
fix typo: sucesfully -> successfully in uninstall message

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -7,4 +7,4 @@ fi
 # Deletes spongebob-cli executable
 rm /usr/bin/spongebob-cli || rm /usr/local/bin/spongebob-cli 
 
-echo "spongebob-cli has been sucesfully uninstalled."
+echo "spongebob-cli has been successfully uninstalled."


### PR DESCRIPTION
Fixes the typo 'sucesfully' → 'successfully' in the uninstall confirmation message in uninstall.sh.

The echo message at the end of the uninstall script was misspelled as 'sucesfully' instead of 'successfully'.

**Before:** `echo "spongebob-cli has been sucesfully uninstalled."`
**After:** `echo "spongebob-cli has been successfully uninstalled."`

Minimal one-line fix, no other changes.